### PR TITLE
fix: correct widget test import

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:alitogroupv02/main.dart';
+import 'package:alirogroupv01/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- fix widget test import to use `alirogroupv01`

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*
- `dart test test/widget_test.dart` *(fails: command not found)*
- `dart format test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60e7b1eb88328b63723596dc70417