### PR TITLE
Allow desktop window to reach full screen

### DIFF
--- a/lib/desktop/desktop_window.dart
+++ b/lib/desktop/desktop_window.dart
@@ -20,16 +20,16 @@ Future<void> setupDesktopWindow() async {
         final windowWidth = screen.visibleFrame.width * 0.8;
         final windowHeight = screen.visibleFrame.height * 0.8;
 
-        // Establecer tamaño inicial de ventana
-        setWindowMaxSize(Size(windowWidth, windowHeight));
-
         // Centrar la ventana en la pantalla
         final left = (screen.visibleFrame.width - windowWidth) / 2;
         final top = (screen.visibleFrame.height - windowHeight) / 2;
         setWindowFrame(Rect.fromLTWH(left, top, windowWidth, windowHeight));
+
+        // Permitir que la ventana se maximice hasta el tamaño completo de la pantalla
+        setWindowMaxSize(screen.visibleFrame.size);
       } else {
         // Si no se puede obtener información de la pantalla, usar valores predeterminados
-        setWindowMaxSize(const Size(1280, 800));
+        setWindowFrame(const Rect.fromLTWH(0, 0, 1280, 800));
       }
 
       // Establecer título de la ventana


### PR DESCRIPTION
## Summary
- enable maximizing desktop window to full screen by capping max size to the screen's visible frame
- set a default frame when screen information isn't available

## Testing
- `dart format lib/desktop/desktop_window.dart` *(fails: command not found)*
- `flutter format lib/desktop/desktop_window.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b61b4cc5508328a606cba51946951f